### PR TITLE
Rescale log-likelihood in FFBS

### DIFF
--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,4 +1,8 @@
-import theano
+import warnings
+
+with warnings.catch_warnings():
+    warnings.filterwarnings("ignore", category=DeprecationWarning)
+    import theano
 
 import pymc3
 

--- a/tests/test_step_methods.py
+++ b/tests/test_step_methods.py
@@ -1,3 +1,5 @@
+import warnings
+
 import numpy as np
 import scipy as sp
 
@@ -20,8 +22,8 @@ def test_ffbs_astep():
 
     np.random.seed(2032)
 
-    test_lik_0 = np.stack([np.repeat(1.0, 10000), np.repeat(0.0, 10000)], 1)
-    test_lik_1 = np.stack([np.repeat(0.0, 10000), np.repeat(1.0, 10000)], 1)
+    test_log_lik_0 = np.stack([np.repeat(0.0, 10000), np.repeat(-np.inf, 10000)], 1)
+    test_log_lik_1 = np.stack([np.repeat(-np.inf, 10000), np.repeat(0.0, 10000)], 1)
 
     test_Gamma_t = np.c_[[0.9, 0.1], [0.1, 0.9]].T
     test_gamma_0 = np.r_[0.5, 0.5]
@@ -33,20 +35,23 @@ def test_ffbs_astep():
         np.random.poisson(10, 10000),
         np.random.poisson(50, 10000),
     )
-    test_lik_p = np.stack(
-        [sp.stats.poisson.pmf(test_obs, 10), sp.stats.poisson.pmf(test_obs, 50)], 1
+    test_log_lik_p = np.stack(
+        [sp.stats.poisson.logpmf(test_obs, 10), sp.stats.poisson.logpmf(test_obs, 50)],
+        1,
     )
 
     # TODO FIXME: This is a statistically unsound/unstable check.
-    assert np.mean(test_lik_p.argmax(1) - test_seq) < 1e-2
+    assert np.mean(np.abs(test_log_lik_p.argmax(1) - test_seq)) < 1e-2
 
-    res = ffbs_astep(test_gamma_0, test_Gamma_t, test_lik_0)
+    res = ffbs_astep(test_gamma_0, test_Gamma_t, test_log_lik_0)
     assert np.all(res == 0)
-    res = ffbs_astep(test_gamma_0, test_Gamma_t, test_lik_1)
+
+    res = ffbs_astep(test_gamma_0, test_Gamma_t, test_log_lik_1)
     assert np.all(res == 1)
-    res = ffbs_astep(test_gamma_0, test_Gamma_t, test_lik_p)
+
+    res = ffbs_astep(test_gamma_0, test_Gamma_t, test_log_lik_p)
     # TODO FIXME: This is a statistically unsound/unstable check.
-    assert np.mean(res - test_seq) < 1e-2
+    assert np.mean(np.abs(res - test_seq)) < 1e-2
 
 
 def test_FFBSStep():
@@ -78,11 +83,63 @@ def test_FFBSStep():
 
     res = ffbs.step(test_point)
 
-    # TODO: Is this really a good unit test?
-    # assert np.array_equal(res['S_t'], poiszero_sim['S_t'])
-    assert (
-        np.sum(res["S_t"] - poiszero_sim["S_t"]) / poiszero_sim["S_t"].shape[0] < 0.01
-    )
+    assert np.array_equal(res["S_t"], poiszero_sim["S_t"])
+
+
+def test_FFBSStep_extreme():
+    """Test a long series with extremely large mixture separation (and, thus, very small likelihoods)."""
+
+    np.random.seed(2032)
+
+    poiszero_sim, _ = simulate_poiszero_hmm(9000, 5000)
+    y_test = poiszero_sim["Y_t"]
+
+    with pm.Model() as test_model:
+        p_0_rv = poiszero_sim["p_0"]
+        p_1_rv = poiszero_sim["p_1"]
+
+        P_tt = tt.stack([p_0_rv, p_1_rv])
+        P_rv = pm.Deterministic("P_tt", P_tt)
+
+        pi_0_tt = poiszero_sim["pi_0"]
+
+        S_rv = HMMStateSeq("S_t", y_test.shape[0], P_rv, pi_0_tt)
+        # S_rv.tag.test_value = (y_test > 0).astype(np.int)
+
+        E_mu, Var_mu = 10.0, 10.0
+        mu_rv = pm.Gamma("mu", E_mu ** 2 / Var_mu, E_mu / Var_mu)
+
+        Y_rv = PoissonZeroProcess("Y_t", mu_rv, S_rv, observed=y_test)
+
+    with test_model:
+        ffbs = FFBSStep([S_rv])
+
+    test_point = test_model.test_point.copy()
+    test_point["p_0_stickbreaking__"] = poiszero_sim["p_0_stickbreaking__"]
+    test_point["p_1_stickbreaking__"] = poiszero_sim["p_1_stickbreaking__"]
+
+    res = ffbs.step(test_point)
+
+    assert np.array_equal(res["S_t"], poiszero_sim["S_t"])
+
+    # Now, make sure that NUTS doesn't fail right away
+    with test_model, np.errstate(
+        over="ignore", under="raise"
+    ), warnings.catch_warnings():
+        warnings.filterwarnings("ignore", category=UserWarning)
+        mu_step = pm.NUTS([mu_rv])
+        ffbs = FFBSStep([S_rv])
+        steps = [ffbs, mu_step]
+        trace = pm.sample(
+            5,
+            init="adapt_diag",
+            step=steps,
+            cores=1,
+            chains=1,
+            tune=1,
+            n_init=1,
+            progressbar=False,
+        )
 
 
 def test_TransMatConjugateStep():


### PR DESCRIPTION
This change should fix/improve the tests for FFBS and prevent PyMC3's NUTS sampler from initially erring due to numerical issues.