### PR TITLE
Rename HMMStateSeq to DiscreteMarkovChain

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 Hidden Markov models in [PyMC3](https://github.com/pymc-devs/pymc3).
 
 ### Features
-- Fully implemented PyMC3 `Distribution` classes for HMM state sequences (`HMMStateSeq`) and mixtures that are driven by them (`SwitchingProcess`)
+- Fully implemented PyMC3 `Distribution` classes for HMM state sequences (`DiscreteMarkovChain`) and mixtures that are driven by them (`SwitchingProcess`)
 - A forward-filtering backward-sampling (FFBS) implementation (`FFBSStep`) that works with NUTS&mdash;or any other PyMC3 sampler
 - A conjugate Dirichlet transition matrix sampler (`TransMatConjugateStep`)
 - Support for time-varying transition matrices in the FFBS sampler and all the relevant `Distribution` classes

--- a/examples/poisson_zero_example.ipynb
+++ b/examples/poisson_zero_example.ipynb
@@ -24,7 +24,7 @@
     "import pymc3 as pm\n",
     "\n",
     "from pymc3_hmm.utils import compute_steady_state\n",
-    "from pymc3_hmm.distributions import SwitchingProcess, HMMStateSeq\n",
+    "from pymc3_hmm.distributions import SwitchingProcess, DiscreteMarkovChain\n",
     "from pymc3_hmm.step_methods import FFBSStep, TransMatConjugateStep"
    ]
   },
@@ -106,7 +106,7 @@
     "\n",
     "    pi_0_tt = compute_steady_state(P_rv)\n",
     "\n",
-    "    S_rv = HMMStateSeq(\"S_t\", P_rv, pi_0_tt, shape=np.shape(observed)[-1])\n",
+    "    S_rv = DiscreteMarkovChain(\"S_t\", P_rv, pi_0_tt, shape=np.shape(observed)[-1])\n",
     "\n",
     "    Y_rv = SwitchingProcess(\n",
     "        \"Y_t\", [pm.Constant.dist(0), pm.Poisson.dist(mu)], S_rv, observed=observed\n",

--- a/examples/poisson_zero_time_varying_example.ipynb
+++ b/examples/poisson_zero_time_varying_example.ipynb
@@ -27,7 +27,7 @@
     "import pymc3 as pm\n",
     "\n",
     "from pymc3_hmm.utils import multilogit_inv\n",
-    "from pymc3_hmm.distributions import SwitchingProcess, HMMStateSeq\n",
+    "from pymc3_hmm.distributions import SwitchingProcess, DiscreteMarkovChain\n",
     "from pymc3_hmm.step_methods import FFBSStep"
    ]
   },
@@ -114,7 +114,7 @@
     "\n",
     "    P_rv = pm.Deterministic(\"P_t\", P_tt)\n",
     "\n",
-    "    S_rv = HMMStateSeq(\"S_t\", P_rv, pi_0, shape=np.shape(observed)[-1])\n",
+    "    S_rv = DiscreteMarkovChain(\"S_t\", P_rv, pi_0, shape=np.shape(observed)[-1])\n",
     "\n",
     "    Y_rv = SwitchingProcess(\n",
     "        \"Y_t\", [pm.Constant.dist(0), pm.Poisson.dist(mu)], S_rv, observed=observed\n",

--- a/pymc3_hmm/__init__.py
+++ b/pymc3_hmm/__init__.py
@@ -1,4 +1,4 @@
-from pymc3_hmm.distributions import HMMStateSeq, SwitchingProcess
+from pymc3_hmm.distributions import DiscreteMarkovChain, SwitchingProcess
 from pymc3_hmm.step_methods import FFBSStep, TransMatConjugateStep
 from pymc3_hmm.utils import compute_steady_state
 

--- a/pymc3_hmm/distributions.py
+++ b/pymc3_hmm/distributions.py
@@ -113,7 +113,7 @@ class SwitchingProcess(pm.Distribution):
         comp_dists : list of Distribution
             A list containing `Distribution` objects for each mixture component.
             These are essentially the emissions distributions.
-        states : HMMStateSeq
+        states : DiscreteMarkovChain
             The hidden state sequence.  It should have a number of states
             equal to the size of `comp_dists`.
 
@@ -273,16 +273,17 @@ class PoissonZeroProcess(SwitchingProcess):
         super().__init__([pm.Constant.dist(0), pm.Poisson.dist(mu)], states, **kwargs)
 
 
-class HMMStateSeq(pm.Discrete):
-    """A hidden markov state sequence distribution.
+class DiscreteMarkovChain(pm.Discrete):
+    """A first-order discrete Markov chain distribution.
 
     This class characterizes vector random variables consisting of state
-    indicator values (i.e. `0` to `M - 1`).
+    indicator values (i.e. `0` to `M - 1`) that are driven by a discrete Markov
+    chain.
 
     """
 
     def __init__(self, Gamma, gamma_0, shape, **kwargs):
-        """Initialize an `HMMStateSeq` object.
+        """Initialize an `DiscreteMarkovChain` object.
 
         Parameters
         ----------
@@ -313,7 +314,7 @@ class HMMStateSeq(pm.Discrete):
         super().__init__(shape=shape, **kwargs)
 
     def logp(self, states):
-        r"""Create a Theano graph that computes the log-likelihood for a state sequence.
+        r"""Create a Theano graph that computes the log-likelihood for a discrete Markov chain.
 
         This is the log-likelihood for the joint distribution of states, :math:`S_t`, conditional
         on state samples, :math:`s_t`, given by the following:
@@ -383,12 +384,12 @@ class HMMStateSeq(pm.Discrete):
         logp_S_1T = tt.log(P_S_2T[obs_slices])
 
         res = logp_S_1 + tt.sum(logp_S_1T, axis=-1)
-        res.name = "HMMStateSeq_logp"
+        res.name = "DiscreteMarkovChain_logp"
 
         return res
 
     def random(self, point=None, size=None):
-        """Sample from this distribution conditional on a given set of values.
+        """Sample from a discrete Markov chain conditional on a given set of values.
 
         Parameters
         ----------

--- a/pymc3_hmm/step_methods.py
+++ b/pymc3_hmm/step_methods.py
@@ -10,7 +10,7 @@ from theano.gof.op import get_test_value as test_value
 
 from pymc3.step_methods.arraystep import ArrayStep, Competence
 
-from pymc3_hmm.distributions import HMMStateSeq
+from pymc3_hmm.distributions import DiscreteMarkovChain
 from pymc3_hmm.utils import compute_trans_freqs
 
 
@@ -164,7 +164,7 @@ class FFBSStep(ArrayStep):
     def competence(var):
         distribution = getattr(var.distribution, "parent_dist", var.distribution)
 
-        if isinstance(distribution, HMMStateSeq):
+        if isinstance(distribution, DiscreteMarkovChain):
             return Competence.IDEAL
         # elif isinstance(distribution, pm.Bernoulli) or (var.dtype in pm.bool_types):
         #     return Competence.COMPATIBLE
@@ -209,7 +209,7 @@ class TransMatConjugateStep(ArrayStep):
         ----------
         dir_priors : list of Dirichlets
             State-ordered from-to prior transition probabilities.
-        hmm_states : HMMStateSeq
+        hmm_states : DiscreteMarkovChain
             The HMM state sequence that uses `dir_priors` as its transition matrix.
         """
 

--- a/tests/test_distributions.py
+++ b/tests/test_distributions.py
@@ -8,29 +8,35 @@ import theano.tensor as tt
 from tests.utils import simulate_poiszero_hmm
 from pymc3_hmm.distributions import (
     PoissonZeroProcess,
-    HMMStateSeq,
+    DiscreteMarkovChain,
     SwitchingProcess,
     distribution_subset_args,
 )
 
 
-def test_HMMStateSeq_random():
+def test_DiscreteMarkovChain_random():
     # A single transition matrix and initial probabilities vector for each
     # element in the state sequence
     test_Gamma = np.array([[[1.0, 0.0], [0.0, 1.0]]])
     test_gamma_0 = np.r_[0.0, 1.0]
-    test_sample = HMMStateSeq.dist(test_Gamma, test_gamma_0, shape=10).random()
+    test_sample = DiscreteMarkovChain.dist(test_Gamma, test_gamma_0, shape=10).random()
     assert np.all(test_sample == 1)
 
-    test_sample = HMMStateSeq.dist(test_Gamma, 1.0 - test_gamma_0, shape=10).random()
+    test_sample = DiscreteMarkovChain.dist(
+        test_Gamma, 1.0 - test_gamma_0, shape=10
+    ).random()
     assert np.all(test_sample == 0)
-    test_sample = HMMStateSeq.dist(test_Gamma, test_gamma_0, shape=10).random(size=12)
+    test_sample = DiscreteMarkovChain.dist(test_Gamma, test_gamma_0, shape=10).random(
+        size=12
+    )
     assert test_sample.shape == (
         12,
         10,
     )
 
-    test_sample = HMMStateSeq.dist(test_Gamma, test_gamma_0, shape=10).random(size=2)
+    test_sample = DiscreteMarkovChain.dist(test_Gamma, test_gamma_0, shape=10).random(
+        size=2
+    )
     assert np.array_equal(
         test_sample, np.stack([np.ones(10), np.ones(10)], 0).astype(int)
     )
@@ -39,7 +45,9 @@ def test_HMMStateSeq_random():
     # samples
     test_Gamma = np.array([[[0.8, 0.2], [0.2, 0.8]]])
     test_gamma_0 = np.r_[0.2, 0.8]
-    test_sample = HMMStateSeq.dist(test_Gamma, test_gamma_0, shape=10).random(size=2)
+    test_sample = DiscreteMarkovChain.dist(test_Gamma, test_gamma_0, shape=10).random(
+        size=2
+    )
     # TODO: Fix the seed, and make sure there's at least one 0 and 1?
     assert test_sample.shape == (2, 10)
 
@@ -49,7 +57,7 @@ def test_HMMStateSeq_random():
         [np.array([[[1.0, 0.0], [0.0, 1.0]]]), np.array([[[1.0, 0.0], [0.0, 1.0]]])]
     )
     test_gamma_0 = np.r_[0.0, 1.0]
-    test_dist = HMMStateSeq.dist(test_Gamma, test_gamma_0, shape=(2, 10))
+    test_dist = DiscreteMarkovChain.dist(test_Gamma, test_gamma_0, shape=(2, 10))
     test_sample = test_dist.random()
     assert np.array_equal(
         test_sample, np.stack([np.ones(10), np.ones(10)], 0).astype(int)
@@ -71,7 +79,7 @@ def test_HMMStateSeq_random():
         [np.array([[[1.0, 0.0], [0.0, 1.0]]]), np.array([[[1.0, 0.0], [0.0, 1.0]]])]
     )
     test_gamma_0 = np.stack([np.r_[0.0, 1.0], np.r_[1.0, 0.0]])
-    test_dist = HMMStateSeq.dist(test_Gamma, test_gamma_0, shape=(2, 10))
+    test_dist = DiscreteMarkovChain.dist(test_Gamma, test_gamma_0, shape=(2, 10))
     test_sample = test_dist.random()
     assert np.array_equal(
         test_sample, np.stack([np.ones(10), np.zeros(10)], 0).astype(int)
@@ -99,7 +107,7 @@ def test_HMMStateSeq_random():
     )
     test_gamma_0 = np.r_[1, 0]
 
-    test_dist = HMMStateSeq.dist(test_Gamma, test_gamma_0, shape=3)
+    test_dist = DiscreteMarkovChain.dist(test_Gamma, test_gamma_0, shape=3)
     test_sample = test_dist.random()
     assert np.array_equal(test_sample, np.r_[1, 0, 0])
 
@@ -120,7 +128,7 @@ def test_HMMStateSeq_random():
     )
     test_gamma_0 = np.array([[1, 0], [0, 1]])
 
-    test_dist = HMMStateSeq.dist(test_Gamma, test_gamma_0, shape=(2, 3))
+    test_dist = DiscreteMarkovChain.dist(test_Gamma, test_gamma_0, shape=(2, 3))
     test_sample = test_dist.random()
     assert np.array_equal(test_sample, np.array([[1, 0, 0], [0, 1, 1]]))
 
@@ -150,7 +158,7 @@ def test_HMMStateSeq_random():
     )
     test_gamma_0 = np.array([[1, 0], [0, 1]])
 
-    test_dist = HMMStateSeq.dist(test_Gamma, test_gamma_0, shape=(2, 3))
+    test_dist = DiscreteMarkovChain.dist(test_Gamma, test_gamma_0, shape=(2, 3))
     test_sample = test_dist.random()
     assert np.array_equal(test_sample, np.array([[1, 0, 0], [1, 1, 0]]))
 
@@ -162,7 +170,7 @@ def test_HMMStateSeq_random():
     )
 
 
-def test_HMMStateSeq_point():
+def test_DiscreteMarkovChain_point():
     test_Gammas = tt.as_tensor_variable(np.array([[[1.0, 0.0], [0.0, 1.0]]]))
 
     with pm.Model():
@@ -171,20 +179,20 @@ def test_HMMStateSeq_point():
         test_gamma_0 = pm.Dirichlet("gamma_0", np.r_[1.0, 1000.0])
         test_point = {"gamma_0": np.r_[1.0, 0.0]}
         assert np.all(
-            HMMStateSeq.dist(test_Gammas, test_gamma_0, shape=10).random(
+            DiscreteMarkovChain.dist(test_Gammas, test_gamma_0, shape=10).random(
                 point=test_point
             )
             == 0
         )
         assert np.all(
-            HMMStateSeq.dist(test_Gammas, 1.0 - test_gamma_0, shape=10).random(
+            DiscreteMarkovChain.dist(test_Gammas, 1.0 - test_gamma_0, shape=10).random(
                 point=test_point
             )
             == 1
         )
 
 
-def test_HMMStateSeq_logp():
+def test_DiscreteMarkovChain_logp():
     theano.config.compute_test_value = "warn"
 
     # A single transition matrix and initial probabilities vector for each
@@ -193,7 +201,9 @@ def test_HMMStateSeq_logp():
     test_gamma_0 = np.r_[1.0, 0.0]
     test_obs = np.r_[1, 0, 1, 0]
 
-    test_dist = HMMStateSeq.dist(test_Gammas, test_gamma_0, shape=test_obs.shape[-1])
+    test_dist = DiscreteMarkovChain.dist(
+        test_Gammas, test_gamma_0, shape=test_obs.shape[-1]
+    )
     test_logp_tt = test_dist.logp(test_obs)
     assert test_logp_tt.eval() == 0
 
@@ -213,7 +223,9 @@ def test_HMMStateSeq_logp():
 
     test_obs = np.r_[1, 0, 1, 0]
 
-    test_dist = HMMStateSeq.dist(test_Gammas, test_gamma_0, shape=test_obs.shape[-1])
+    test_dist = DiscreteMarkovChain.dist(
+        test_Gammas, test_gamma_0, shape=test_obs.shape[-1]
+    )
 
     test_logp_tt = test_dist.logp(test_obs)
 
@@ -226,7 +238,9 @@ def test_HMMStateSeq_logp():
 
     test_gamma_0 = np.r_[0.5, 0.5]
 
-    test_dist = HMMStateSeq.dist(test_Gammas, test_gamma_0, shape=test_obs.shape[-1])
+    test_dist = DiscreteMarkovChain.dist(
+        test_Gammas, test_gamma_0, shape=test_obs.shape[-1]
+    )
 
     test_logp_tt = test_dist.logp(test_obs)
 
@@ -248,7 +262,9 @@ def test_HMMStateSeq_logp():
 
     test_gamma_0 = np.r_[0.5, 0.5]
 
-    test_dist = HMMStateSeq.dist(test_Gammas, test_gamma_0, shape=test_obs.shape[-1])
+    test_dist = DiscreteMarkovChain.dist(
+        test_Gammas, test_gamma_0, shape=test_obs.shape[-1]
+    )
 
     test_logp_tt = test_dist.logp(test_obs)
 
@@ -278,7 +294,9 @@ def test_HMMStateSeq_logp():
 
     test_gamma_0 = np.r_[0.5, 0.5]
 
-    test_dist = HMMStateSeq.dist(test_Gammas, test_gamma_0, shape=test_obs.shape[-1])
+    test_dist = DiscreteMarkovChain.dist(
+        test_Gammas, test_gamma_0, shape=test_obs.shape[-1]
+    )
 
     test_logp_tt = test_dist.logp(test_obs)
 
@@ -289,7 +307,9 @@ def test_HMMStateSeq_logp():
     # broadcasting--and two state sequences
     test_gamma_0 = np.array([[0.5, 0.5], [0.5, 0.5]])
 
-    test_dist = HMMStateSeq.dist(test_Gammas, test_gamma_0, shape=test_obs.shape[-1])
+    test_dist = DiscreteMarkovChain.dist(
+        test_Gammas, test_gamma_0, shape=test_obs.shape[-1]
+    )
 
     test_logp_tt = test_dist.logp(test_obs)
 
@@ -312,7 +332,9 @@ def test_HMMStateSeq_logp():
 
     test_obs = np.r_[1, 0, 1, 0]
 
-    test_dist = HMMStateSeq.dist(test_Gammas, test_gamma_0, shape=test_obs.shape[-1])
+    test_dist = DiscreteMarkovChain.dist(
+        test_Gammas, test_gamma_0, shape=test_obs.shape[-1]
+    )
 
     test_logp_tt = test_dist.logp(test_obs)
 
@@ -385,7 +407,7 @@ def test_PoissonZeroProcess_point():
     assert np.all(test_sample[..., test_states > 0] < 200)
 
 
-def test_random_PoissonZeroProcess_HMMStateSeq():
+def test_random_PoissonZeroProcess_DiscreteMarkovChain():
     poiszero_sim, test_model = simulate_poiszero_hmm(30, 5000)
 
     y_test = poiszero_sim["Y_t"].squeeze()

--- a/tests/test_step_methods.py
+++ b/tests/test_step_methods.py
@@ -14,7 +14,7 @@ from theano.gof.op import get_test_value
 from tests.utils import simulate_poiszero_hmm
 
 from pymc3_hmm.utils import compute_steady_state, compute_trans_freqs
-from pymc3_hmm.distributions import PoissonZeroProcess, HMMStateSeq
+from pymc3_hmm.distributions import PoissonZeroProcess, DiscreteMarkovChain
 from pymc3_hmm.step_methods import ffbs_astep, FFBSStep, TransMatConjugateStep
 
 
@@ -106,7 +106,7 @@ def test_FFBSStep():
 
         pi_0_tt = compute_steady_state(P_rv)
 
-        S_rv = HMMStateSeq("S_t", P_rv, pi_0_tt, shape=y_test.shape[0])
+        S_rv = DiscreteMarkovChain("S_t", P_rv, pi_0_tt, shape=y_test.shape[0])
 
         Y_rv = PoissonZeroProcess("Y_t", 9.0, S_rv, observed=y_test)
 
@@ -140,7 +140,7 @@ def test_FFBSStep_extreme():
 
         pi_0_tt = poiszero_sim["pi_0"]
 
-        S_rv = HMMStateSeq("S_t", P_rv, pi_0_tt, shape=y_test.shape[0])
+        S_rv = DiscreteMarkovChain("S_t", P_rv, pi_0_tt, shape=y_test.shape[0])
 
         # This prior is very far from the true value...
         E_mu, Var_mu = 10.0, 1000.0
@@ -198,7 +198,7 @@ def test_TransMatConjugateStep():
 
         pi_0_tt = compute_steady_state(P_rv)
 
-        S_rv = HMMStateSeq("S_t", P_rv, pi_0_tt, shape=y_test.shape[0])
+        S_rv = DiscreteMarkovChain("S_t", P_rv, pi_0_tt, shape=y_test.shape[0])
 
         Y_rv = PoissonZeroProcess("Y_t", 9.0, S_rv, observed=y_test)
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -4,7 +4,7 @@ import theano.tensor as tt
 
 import pymc3 as pm
 
-from pymc3_hmm.distributions import PoissonZeroProcess, HMMStateSeq
+from pymc3_hmm.distributions import PoissonZeroProcess, DiscreteMarkovChain
 
 
 def simulate_poiszero_hmm(
@@ -20,7 +20,7 @@ def simulate_poiszero_hmm(
 
         pi_0_tt = pm.Dirichlet("pi_0", pi_0_a)
 
-        S_rv = HMMStateSeq("S_t", P_rv, pi_0_tt, shape=N)
+        S_rv = DiscreteMarkovChain("S_t", P_rv, pi_0_tt, shape=N)
 
         Y_rv = PoissonZeroProcess("Y_t", mu, S_rv, observed=np.zeros(N))
 


### PR DESCRIPTION
The `HMMStateSeq` class was not an HMM, so the name wasn't appropriate.  This PR renames `HMMStateSeq` to `DiscreteMarkovChain`.