### PR TITLE
Add an Actions workflow for PyPI

### DIFF
--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -1,0 +1,50 @@
+name: PyPI
+on:
+  push:
+    branches:
+      - master
+      - auto-release
+  pull_request:
+    branches: [master]
+  release:
+    types: [published]
+
+jobs:
+  build:
+    name: Build source distribution
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-python@v2
+        with:
+          python-version: "3.8"
+      - name: Build the sdist
+        run: |
+          python setup.py sdist
+      - name: Check that the sdist build installs
+        run: |
+          mkdir -p test-sdist
+          cd test-sdist
+          python -m venv venv-sdist
+          venv-sdist/bin/python -m pip install ../dist/pymc3-hmm-*
+      - uses: actions/upload-artifact@v2
+        with:
+          name: artifact
+          path: dist/*
+
+  upload_pypi:
+    name: Upload to PyPI on release
+    needs: [build]
+    runs-on: ubuntu-latest
+    if: github.event_name == 'release' && github.event.action == 'published'
+    steps:
+      - uses: actions/download-artifact@v2
+        with:
+          name: artifact
+          path: dist
+      - uses: pypa/gh-action-pypi-publish@master
+        with:
+          user: __token__
+          password: ${{ secrets.pypi_secret }}

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ setup(
     zip_safe=False,
     python_requires=">=3.6",
     classifiers=[
-        "Development Status :: 5 - Production/Stable",
+        "Development Status :: 4 - Beta",
         "Intended Audience :: Science/Research",
         "Intended Audience :: Developers",
         "License :: OSI Approved :: Apache Software License",


### PR DESCRIPTION
This PR adds an Actions workflow for PyPI.

~It's currently set up to use `dependency_links` per #38, but that doesn't seem to work, so we'll probably need to wait for the next release of PyMC3 to merge this (after removing `dependency_links`, of course).~