### PR TITLE
Fix indexing in SwitchingProcess.logp

### DIFF
--- a/pymc3_hmm/distributions.py
+++ b/pymc3_hmm/distributions.py
@@ -197,14 +197,8 @@ class SwitchingProcess(pm.Distribution):
         for i, dist in enumerate(self.comp_dists):
             i_mask = tt.eq(self.states, i)
             obs_i = obs_tt[i_mask]
-            i_idx = tt.unravel_index(
-                tt.arange(tt.mul(self.states.shape)[0])[i_mask.ravel()],
-                self.states.shape,
-            )
-            subset_dist = dist.dist(*distribution_subset_args(dist, obs.shape, i_idx))
-            logp_val = tt.set_subtensor(logp_val[i_idx], subset_dist.logp(obs_i))
-
-        logp_val.name = "SwitchingProcess_logp"
+            subset_dist = dist.dist(*distribution_subset_args(dist, obs.shape, i_mask))
+            logp_val = tt.set_subtensor(logp_val[i_mask], subset_dist.logp(obs_i))
 
         return logp_val
 

--- a/tests/test_distributions.py
+++ b/tests/test_distributions.py
@@ -502,6 +502,19 @@ def test_SwitchingProcess():
         with pytest.raises(ValueError):
             SwitchingProcess.dist([test_dist], test_states)
 
+    # Evaluate multiple observed state sequences in an extreme case
+    test_states = tt.imatrix("states")
+    test_states.tag.test_value = np.zeros((10, 4)).astype("int32")
+    test_dist = SwitchingProcess.dist(
+        [pm.Constant.dist(0), pm.Constant.dist(1)], test_states
+    )
+    test_obs = np.tile(np.arange(4), (10, 1)).astype("int32")
+    test_logp = test_dist.logp(test_obs)
+    exp_logp = np.tile(
+        np.array([0.0] + [-np.inf] * 3, dtype=theano.config.floatX), (10, 1)
+    )
+    assert np.array_equal(test_logp.tag.test_value, exp_logp)
+
 
 def test_subset_args():
 


### PR DESCRIPTION
This PR closes #47 and is likely to improve the speed of `SwitchingProcess.logp`, since it avoids the construction of a potentially large intermediate index array.