### PR TITLE
Indexing aware TransMatConjugateStep

### DIFF
--- a/examples/poisson_zero_example.ipynb
+++ b/examples/poisson_zero_example.ipynb
@@ -209,7 +209,7 @@
     "    _ = create_poisson_zero_hmm(mu_rv, y_t, p_0_a=np.r_[1, 1], p_1_a=np.r_[1, 1])\n",
     "\n",
     "with test_model:\n",
-    "    transmat_step = TransMatConjugateStep([test_model.p_0, test_model.p_1], test_model.S_t)\n",
+    "    transmat_step = TransMatConjugateStep(test_model.P_rv)\n",
     "    states_step = FFBSStep([test_model.S_t])\n",
     "    mu_step = pm.NUTS([test_model.mu])\n",
     "\n",

--- a/pymc3_hmm/distributions.py
+++ b/pymc3_hmm/distributions.py
@@ -289,7 +289,7 @@ class DiscreteMarkovChain(pm.Discrete):
 
     """
 
-    def __init__(self, Gamma, gamma_0, shape, **kwargs):
+    def __init__(self, Gammas, gamma_0, shape, **kwargs):
         """Initialize an `DiscreteMarkovChain` object.
 
         Parameters
@@ -309,9 +309,9 @@ class DiscreteMarkovChain(pm.Discrete):
         """
         self.gamma_0 = tt.as_tensor_variable(pm.floatX(gamma_0))
 
-        assert Gamma.ndim >= 3
+        assert Gammas.ndim >= 3
 
-        self.Gammas = tt.as_tensor_variable(pm.floatX(Gamma))
+        self.Gammas = tt.as_tensor_variable(pm.floatX(Gammas))
 
         shape = np.atleast_1d(shape)
 
@@ -443,3 +443,6 @@ class DiscreteMarkovChain(pm.Discrete):
                 states[..., n] = state_n
 
             return states
+
+    def _distr_parameters_for_repr(self):
+        return ["Gammas", "gamma_0"]

--- a/tests/test_distributions.py
+++ b/tests/test_distributions.py
@@ -16,6 +16,19 @@ from pymc3_hmm.distributions import (
 )
 
 
+def test_DiscreteMarkovChain_str():
+    Gammas = tt.as_tensor(np.eye(2)[None, ...], name="Gammas")
+    gamma_0 = tt.as_tensor(np.r_[0, 1], name="gamma_0")
+
+    with pm.Model():
+        test_dist = DiscreteMarkovChain("P_rv", Gammas, gamma_0, shape=(2,))
+
+    assert (
+        str(test_dist)
+        == "P_rv ~ DiscreteMarkovChain(Gammas=Gammas, gamma_0=f(gamma_0))"
+    )
+
+
 def test_DiscreteMarkovChain_random():
     # A single transition matrix and initial probabilities vector for each
     # element in the state sequence


### PR DESCRIPTION
This PR gives `TransMatConjugateStep` the ability to perform conjugate updates for Dirichlet priors contained within a larger transition matrix.

For example, `TransMatConjugateStep` will now work with the following transition matrix:
```python
import numpy as np

import theano.tensor as tt

import pymc3 as pm


with pm.Model():
    d_0_rv = pm.Dirichlet("p_0", np.r_[1, 1])
    d_1_rv = pm.Dirichlet("p_1", np.r_[1, 1])

    p_0_rv = tt.as_tensor([0, 0, 1])
    p_1_rv = tt.zeros(3)
    p_1_rv = tt.set_subtensor(p_0_rv[[0, 2]], d_0_rv)
    p_2_rv = tt.zeros(3)
    p_2_rv = tt.set_subtensor(p_1_rv[[1, 2]], d_1_rv)

    P_tt = tt.stack([p_0_rv, p_1_rv, p_2_rv])

```

This allows one to specify transition matrices with fixed transition logic *and* transitions that are to be "learned".