### PR TITLE
Remove strict PyMC3 and Theano-PyMC version requirements

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,8 +17,8 @@ setup(
     install_requires=[
         "numpy>=1.18.1",
         "scipy>=1.4.0",
-        "pymc3==3.11.0",
-        "theano-pymc==1.1.0",
+        "pymc3>=3.11.0",
+        "theano-pymc>=1.1.0",
     ],
     tests_require=["pytest"],
     long_description=open("README.md").read() if exists("README.md") else "",


### PR DESCRIPTION
This PR removes the strict PyMC3 and Theano-PyMC requirements and allows one to use more recent versions.