### PR TITLE
Set axis labels automatically with AutoDateLocator

### DIFF
--- a/pymc3_hmm/utils.py
+++ b/pymc3_hmm/utils.py
@@ -275,10 +275,10 @@ def plot_split_timeseries(
     axes : list of axes
         The generated plot axes.
     """  # noqa: E501
-    import matplotlib.dates as mdates
     import matplotlib.pyplot as plt
     import matplotlib.transforms as mtrans
     import pandas as pd
+    from matplotlib.dates import AutoDateFormatter, AutoDateLocator
 
     if plot_fn is None:
 
@@ -320,10 +320,10 @@ def plot_split_timeseries(
 
         plot_fn(ax, split_data, drawstyle=drawstyle, linewidth=linewidth, **plot_kwds)
 
-        ax.xaxis.set_minor_locator(mdates.HourLocator(byhour=range(0, 23, 3)))
-        ax.xaxis.set_minor_formatter(mdates.DateFormatter("%H"))
-        ax.xaxis.set_major_locator(mdates.WeekdayLocator(byweekday=range(0, 7, 1)))
-        ax.xaxis.set_major_formatter(mdates.DateFormatter("%Y-%m-%d %a"))
+        locator = AutoDateLocator()
+        formatter = AutoDateFormatter(locator)
+        ax.xaxis.set_major_locator(locator)
+        ax.xaxis.set_major_formatter(formatter)
 
         # Shift the major tick labels down
         for xlabel in ax.xaxis.get_majorticklabels():


### PR DESCRIPTION
This PR attempts to de-clutter the x-axis labels for large split frequencies by leveraging matplotlib's AutoDateLocator. Currently date formats are being determined by matplotlib's `ConciseDateFormatter` but another option could be to use the `AutoDateFormatter` instead, depending on style preference. As for unit tests, is this a change that requires writing a test case? I couldn't think of a good way to write a test for this, if so.

Here are a few important guidelines and requirements to check before your PR can be merged:
+ [ ] There is an informative high-level description of the changes.
+ [ ] The description and/or commit message(s) references the relevant GitHub issue(s).
+ [ ] The commit messages follow [these guidelines](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html).
+ [ ] The commits correspond to [relevant logical changes](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes).
+ [ ] There are tests covering the changes introduced in the PR.

Don't worry, your PR doesn't need to be in perfect order to submit it.  As development progresses and/or reviewers request changes, you can always [rewrite the history](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History#_rewriting_history) of your feature/PR branches.

If your PR is an ongoing effort and you would like to involve us in the process, simply make it a [draft PR](https://docs.github.com/en/free-pro-team@latest/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests).
