### PR TITLE
Remove premature use of Aesara

### DIFF
--- a/pymc3_hmm/utils.py
+++ b/pymc3_hmm/utils.py
@@ -2,8 +2,8 @@ from typing import Any, List
 
 import numpy as np
 import theano.tensor as tt
-from aesara.tensor.var import TensorVariable
 from scipy.special import logsumexp
+from theano.tensor.var import TensorVariable
 
 vsearchsorted = np.vectorize(np.searchsorted, otypes=[np.int], signature="(n),()->()")
 

--- a/setup.py
+++ b/setup.py
@@ -17,9 +17,8 @@ setup(
     install_requires=[
         "numpy>=1.18.1",
         "scipy>=1.4.0",
-        "pymc3>=3.11.0",
+        "pymc3==3.11.1",
         "theano-pymc>=1.1.0",
-        "aesara>=2.0.1",
     ],
     tests_require=["pytest"],
     long_description=open("README.md").read() if exists("README.md") else "",


### PR DESCRIPTION
This PR fixes a premature use of Aesara and upper bounds the PyMC3 version to avoid future Aesara/Theano-PyMC conflicts.  In general, e need to wait for the next release of PyMC3 before we can use Aesara.