### PR TITLE
Update pymc3 version to 3.11.2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ setup(
     install_requires=[
         "numpy>=1.18.1",
         "scipy>=1.4.0",
-        "pymc3==3.11.1",
+        "pymc3==3.11.2",
         "theano-pymc>=1.1.0",
     ],
     tests_require=["pytest"],


### PR DESCRIPTION
This PR updates pymc3 to 3.11.2. We also want to cut a new release of `pymc3-hmm` so that we can import the `plot_predictive_histograms` function
