### PR TITLE
Add and use a custom `Constant` `Distribution`

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -48,7 +48,8 @@ jobs:
     strategy:
       matrix:
         python-version: [3.7]
-        pymc3-version: [stable, dev]
+        pymc3-version: [stable]
+        # pymc3-version: [stable, dev]
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -6,6 +6,13 @@ on:
   pull_request:
     branches: [ main ]
 
+# Cancels all previous workflow runs for pull requests that have not completed.
+concurrency:
+  # The concurrency group contains the workflow name and the branch name for pull requests
+  # or the commit hash for any other events.
+  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.head_ref || github.sha }}
+  cancel-in-progress: true
+
 jobs:
   changes:
     name: "Check for changes"
@@ -55,21 +62,43 @@ jobs:
     - uses: actions/checkout@v2
       with:
         fetch-depth: 0
+
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: conda-incubator/setup-miniconda@v2
       with:
+        mamba-version: "*"
+        channels: conda-forge,defaults
+        channel-priority: true
         python-version: ${{ matrix.python-version }}
+        auto-update-conda: true
+
     - name: Install dependencies
+      shell: bash -l {0}
       run: |
-        python -m pip install --upgrade pip
+        mamba install --yes -q "python~=${PYTHON_VERSION}=*_cpython" theano-pymc mkl numpy scipy pip mkl-service
         if [[ "${{ matrix.pymc3-version }}" != "stable" ]]; then pip install "pymc3 @ git+https://github.com/pymc-devs/pymc3.git@master"; fi
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+        mamba list && pip freeze
+        python -c 'import theano; print(theano.config.__str__(print_doc=False))'
+        python -c 'import theano; assert(theano.config.blas__ldflags != "")'
+      env:
+        PYTHON_VERSION: ${{ matrix.python-version }}
+
     - name: Test with pytest
+      shell: bash -l {0}
       run: |
-        pytest tests --cov=pymc3_hmm --cov-report=xml:./coverage.xml
+        pytest -x -r A --verbose tests --cov=pymc3_hmm --cov-report=xml:./coverage.xml
+      env:
+        MKL_THREADING_LAYER: GNU
+        MKL_NUM_THREADS: 1
+        OMP_NUM_THREADS: 1
+
     - name: Fetch main for coverage diff
+      shell: bash -l {0}
       run: |
         git fetch --no-tags --prune origin main
+
     - name: Check coverage
+      shell: bash -l {0}
       run: |
         diff-cover ./coverage.xml --compare-branch=origin/main --fail-under=100 --diff-range-notation '..'

--- a/examples/poisson_zero_example.ipynb
+++ b/examples/poisson_zero_example.ipynb
@@ -26,7 +26,7 @@
     "import pymc3 as pm\n",
     "\n",
     "from pymc3_hmm.utils import compute_steady_state\n",
-    "from pymc3_hmm.distributions import SwitchingProcess, DiscreteMarkovChain\n",
+    "from pymc3_hmm.distributions import Constant, SwitchingProcess, DiscreteMarkovChain\n",
     "from pymc3_hmm.step_methods import FFBSStep, TransMatConjugateStep"
    ]
   },
@@ -112,7 +112,7 @@
     "    S_rv.tag.test_value = np.array(observed > 0, dtype=np.int32)\n",
     "\n",
     "    Y_rv = SwitchingProcess(\n",
-    "        \"Y_t\", [pm.Constant.dist(0), pm.Poisson.dist(mu)], S_rv, observed=observed\n",
+    "        \"Y_t\", [Constant.dist(np.array(0, dtype=np.int64)), pm.Poisson.dist(mu)], S_rv, observed=observed\n",
     "    )\n",
     "\n",
     "    return Y_rv\n"

--- a/tests/test_estimation.py
+++ b/tests/test_estimation.py
@@ -20,7 +20,7 @@ except ImportError:
 
 import pymc3 as pm
 
-from pymc3_hmm.distributions import DiscreteMarkovChain, SwitchingProcess
+from pymc3_hmm.distributions import Constant, DiscreteMarkovChain, SwitchingProcess
 from pymc3_hmm.step_methods import FFBSStep
 from pymc3_hmm.utils import multilogit_inv
 
@@ -56,7 +56,7 @@ def create_dirac_zero_hmm(X, mu, xis, observed):
         V_rv.tag.test_value = (observed.get_value() > 0) * 1
     Y_rv = SwitchingProcess(
         "Y_t",
-        [pm.Constant.dist(0), pm.Constant.dist(mu)],
+        [Constant.dist(np.array(0, dtype=np.int64)), Constant.dist(mu)],
         V_rv,
         observed=observed,
     )
@@ -83,7 +83,7 @@ def test_only_positive_state():
 
         _ = SwitchingProcess(
             "Y_t",
-            [pm.Constant.dist(0), pm.Constant.dist(mu)],
+            [Constant.dist(np.array(0, dtype=np.int64)), Constant.dist(mu)],
             V_rv,
             observed=y_t,
         )


### PR DESCRIPTION
This PR fixes some issues with `pymc3.Constant` (e.g. wrong dtypes, a bug that appears when bounds checking is disabled) by way of a custom implementation.