### PR TITLE
Remove conditioning in distribution_subset_args

### DIFF
--- a/tests/test_distributions.py
+++ b/tests/test_distributions.py
@@ -544,21 +544,21 @@ def test_subset_args():
     test_dist = Constant.dist(c=np.r_[0.1, 1.2, 2.3])
     test_idx = np.r_[0, 2]
     res = distribution_subset_args(test_dist, shape=[3], idx=test_idx)
-    assert np.array_equal(res[0].eval(), np.r_[0.1, 2.3])
+    assert np.array_equal(res["c"].eval(), np.r_[0.1, 2.3])
 
     test_dist = pm.Normal.dist(mu=np.r_[0.1, 1.2, 2.3], sigma=np.r_[10.0])
     test_idx = np.r_[0, 2]
     res = distribution_subset_args(test_dist, shape=[3], idx=test_idx)
-    assert np.array_equal(res[0].eval(), np.r_[0.1, 2.3])
-    assert np.array_equal(res[1].eval(), np.r_[10.0, 10.0])
+    assert np.array_equal(res["mu"].eval(), np.r_[0.1, 2.3])
+    assert np.array_equal(res["sigma"].eval(), np.r_[10.0, 10.0])
 
     test_dist = pm.Poisson.dist(mu=np.r_[0.1, 1.2, 2.3])
     test_idx = np.r_[0, 2]
     res = distribution_subset_args(test_dist, shape=[3], idx=test_idx)
-    assert np.array_equal(res[0].eval(), np.r_[0.1, 2.3])
+    assert np.array_equal(res["mu"].eval(), np.r_[0.1, 2.3])
 
     test_dist = pm.NegativeBinomial.dist(mu=np.r_[0.1, 1.2, 2.3], alpha=2)
     test_idx = np.r_[0, 2]
     res = distribution_subset_args(test_dist, shape=[3], idx=test_idx)
-    assert np.array_equal(res[0].eval(), np.r_[0.1, 2.3])
-    assert np.array_equal(res[1].eval(), np.r_[2.0, 2.0])
+    assert np.array_equal(res["mu"].eval(), np.r_[0.1, 2.3])
+    assert np.array_equal(res["alpha"].eval(), np.r_[2.0, 2.0])

--- a/tests/test_distributions.py
+++ b/tests/test_distributions.py
@@ -437,6 +437,7 @@ def test_PoissonZeroProcess_point():
 
     assert np.all(0 < test_sample[..., test_states > 0])
     assert np.all(test_sample[..., test_states > 0] < 200)
+    assert np.all(test_sample[..., test_states == 0] == 0)
 
 
 def test_random_PoissonZeroProcess_DiscreteMarkovChain():
@@ -545,41 +546,19 @@ def test_subset_args():
     res = distribution_subset_args(test_dist, shape=[3], idx=test_idx)
     assert np.array_equal(res[0].eval(), np.r_[0.1, 2.3])
 
-    test_point = {"c": np.r_[2.0, 3.0, 4.0]}
-    test_idx = np.r_[0, 2]
-    res = distribution_subset_args(test_dist, shape=[3], idx=test_idx, point=test_point)
-    assert np.array_equal(res[0].eval(), np.r_[2.0, 4.0])
-
     test_dist = pm.Normal.dist(mu=np.r_[0.1, 1.2, 2.3], sigma=np.r_[10.0])
     test_idx = np.r_[0, 2]
     res = distribution_subset_args(test_dist, shape=[3], idx=test_idx)
     assert np.array_equal(res[0].eval(), np.r_[0.1, 2.3])
     assert np.array_equal(res[1].eval(), np.r_[10.0, 10.0])
 
-    test_point = {"mu": np.r_[2.0, 3.0, 4.0], "sigma": np.r_[20.0, 30.0, 40.0]}
-    test_idx = np.r_[0, 2]
-    res = distribution_subset_args(test_dist, shape=[3], idx=test_idx, point=test_point)
-    assert np.array_equal(res[0].eval(), np.r_[2.0, 4.0])
-    assert np.array_equal(res[1].eval(), np.r_[20.0, 40.0])
-
     test_dist = pm.Poisson.dist(mu=np.r_[0.1, 1.2, 2.3])
     test_idx = np.r_[0, 2]
     res = distribution_subset_args(test_dist, shape=[3], idx=test_idx)
     assert np.array_equal(res[0].eval(), np.r_[0.1, 2.3])
-
-    test_point = {"mu": np.r_[2.0, 3.0, 4.0]}
-    test_idx = np.r_[0, 2]
-    res = distribution_subset_args(test_dist, shape=[3], idx=test_idx, point=test_point)
-    assert np.array_equal(res[0].eval(), np.r_[2.0, 4.0])
 
     test_dist = pm.NegativeBinomial.dist(mu=np.r_[0.1, 1.2, 2.3], alpha=2)
     test_idx = np.r_[0, 2]
     res = distribution_subset_args(test_dist, shape=[3], idx=test_idx)
     assert np.array_equal(res[0].eval(), np.r_[0.1, 2.3])
     assert np.array_equal(res[1].eval(), np.r_[2.0, 2.0])
-
-    test_point = {"mu": np.r_[2.0, 3.0, 4.0], "alpha": np.r_[10, 11, 12]}
-    test_idx = np.r_[0, 2]
-    res = distribution_subset_args(test_dist, shape=[3], idx=test_idx, point=test_point)
-    assert np.array_equal(res[0].eval(), np.r_[2.0, 4.0])
-    assert np.array_equal(res[1].eval(), np.r_[10, 12])


### PR DESCRIPTION
This PR removes the `point` argument and related conditioning logic from `distribution_subset_args` to avoid the potential name conflicts described in #91.

Closes #91.