### PR TITLE
Revert conditional Aesara imports

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,47 +1,27 @@
+exclude: |
+    (?x)^(
+        versioneer\.py|
+        ampersand/_version\.py|
+        doc/.*|
+        bin/.*
+    )$
 repos:
   - repo: https://github.com/psf/black
     rev: 20.8b1
     hooks:
       - id: black
         language_version: python3
-        exclude: |
-            (?x)^(
-                versioneer\.py|
-                ampersand/_version\.py|
-                doc/.*|
-                bin/.*
-            )$
+        additional_dependencies: ['click==8.0.4']
   - repo: https://gitlab.com/pycqa/flake8
     rev: 3.8.4
     hooks:
       - id: flake8
-        exclude: |
-            (?x)^(
-                versioneer\.py|
-                ampersand/_version\.py|
-                doc/.*|
-                bin/.*
-            )$
   - repo: https://github.com/pycqa/isort
     rev: 5.5.2
     hooks:
       - id: isort
-        exclude: |
-            (?x)^(
-                versioneer\.py|
-                ampersand/_version\.py|
-                doc/.*|
-                bin/.*
-            )$
   - repo: https://github.com/pre-commit/mirrors-mypy
     rev: v0.790
     hooks:
       - id: mypy
         args: [--ignore-missing-imports]
-        exclude: |
-            (?x)^(
-                versioneer\.py|
-                pymc3_hmm/_version\.py|
-                doc/.*|
-                bin/.*
-            )$

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,13 +1,8 @@
 import numpy as np
 import pytest
 import scipy as sp
-
-try:
-    import aesara
-    import aesara.tensor as at
-except ImportError:
-    import theano as aesara
-    import theano.tensor as at
+import theano
+import theano.tensor as tt
 
 from pymc3_hmm.utils import (
     compute_trans_freqs,
@@ -40,7 +35,7 @@ def test_compute_trans_freqs():
 )
 def test_logsumexp(test_input):
     np_res = sp.special.logsumexp(test_input)
-    tt_res = tt_logsumexp(at.as_tensor_variable(test_input)).eval()
+    tt_res = tt_logsumexp(tt.as_tensor_variable(test_input)).eval()
     assert np.array_equal(np_res, tt_res)
 
 
@@ -69,33 +64,31 @@ def test_logdotexp():
     assert np.allclose(A.dot(b), np.exp(test_res))
 
 
+@theano.config.change_flags(compute_test_value="warn")
+@np.errstate(over="ignore", under="ignore")
 def test_tt_logdotexp():
-
-    np.seterr(over="ignore", under="ignore")
-
-    aesara.config.compute_test_value = "warn"
 
     A = np.c_[[1.0, 2.0], [3.0, 4.0], [10.0, 20.0]]
     b = np.c_[[0.1], [0.2], [30.0]].T
-    A_tt = at.as_tensor_variable(A)
-    b_tt = at.as_tensor_variable(b)
-    test_res = tt_logdotexp(at.log(A_tt), at.log(b_tt)).eval()
+    A_tt = tt.as_tensor_variable(A)
+    b_tt = tt.as_tensor_variable(b)
+    test_res = tt_logdotexp(tt.log(A_tt), tt.log(b_tt)).eval()
     assert test_res.shape == (2, 1)
     assert np.allclose(A.dot(b), np.exp(test_res))
 
     b = np.r_[0.1, 0.2, 30.0]
-    test_res = tt_logdotexp(at.log(A), at.log(b)).eval()
+    test_res = tt_logdotexp(tt.log(A), tt.log(b)).eval()
     assert test_res.shape == (2,)
     assert np.allclose(A.dot(b), np.exp(test_res))
 
     A = np.c_[[1.0, 2.0], [10.0, 20.0]]
     b = np.c_[[0.1], [0.2]].T
-    test_res = tt_logdotexp(at.log(A), at.log(b)).eval()
+    test_res = tt_logdotexp(tt.log(A), tt.log(b)).eval()
     assert test_res.shape == (2, 1)
     assert np.allclose(A.dot(b), np.exp(test_res))
 
     b = np.r_[0.1, 0.2]
-    test_res = tt_logdotexp(at.log(A), at.log(b)).eval()
+    test_res = tt_logdotexp(tt.log(A), tt.log(b)).eval()
     assert test_res.shape == (2,)
     assert np.allclose(A.dot(b), np.exp(test_res))
 
@@ -122,6 +115,6 @@ def test_multilogit_inv(test_input, test_output):
     assert np.array_equal(res.round(2), test_output)
 
     # Theano testing
-    res = multilogit_inv(at.as_tensor_variable(test_input))
+    res = multilogit_inv(tt.as_tensor_variable(test_input))
     res = res.eval()
     assert np.array_equal(res.round(2), test_output)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,11 +1,6 @@
 import numpy as np
-
-try:
-    import aesara.tensor as at
-except ImportError:
-    import theano.tensor as at
-
 import pymc3 as pm
+import theano.tensor as tt
 
 from pymc3_hmm.distributions import DiscreteMarkovChain, PoissonZeroProcess
 
@@ -18,8 +13,8 @@ def simulate_poiszero_hmm(
         p_0_rv = pm.Dirichlet("p_0", p_0_a, shape=np.shape(pi_0_a))
         p_1_rv = pm.Dirichlet("p_1", p_1_a, shape=np.shape(pi_0_a))
 
-        P_tt = at.stack([p_0_rv, p_1_rv])
-        P_rv = pm.Deterministic("P_tt", at.shape_padleft(P_tt))
+        P_tt = tt.stack([p_0_rv, p_1_rv])
+        P_rv = pm.Deterministic("P_tt", tt.shape_padleft(P_tt))
 
         pi_0_tt = pm.Dirichlet("pi_0", pi_0_a, shape=np.shape(pi_0_a))
 


### PR DESCRIPTION
This PR removes the generalizations that use Aesara over Theano when both are present.  This functionality makes it unnecessarily difficult to use both libraries in tandem with `pymc3-hmm`, and, since this project is pretty specific to PyMC3 (especially in name) and PyMC3 is necessarily specific to Theano, we should revert this functionality for now.